### PR TITLE
Aktualizacja danych dotyczących API /send_encounters

### DIFF
--- a/specs/api.md
+++ b/specs/api.md
@@ -128,8 +128,6 @@ Wysłanie listy napotkanych urządzeń na serwer.
 ### Parametry:
 standardowe
 
-`proof` : `string`
-
 `encounters` : `[{“encounters_date”: datetime, “beacon_id”, “signal_strength”}, …]`
 
 `encounters` - `lista napotkanych urządzeń`
@@ -183,6 +181,15 @@ Serwer zapisuje dane do tabeli `Encounters` wraz z odpowiednim `user_id`.
 
 `is_expired` : `bool`
 
+
+### `Encounter Uploads`
+
+`upload_id` : `string`
+
+`user_id` : `string`
+
+`date` : `datatime`
+
 ## GCP BigQuery
 
 ### `Beacons`
@@ -194,6 +201,8 @@ Serwer zapisuje dane do tabeli `Encounters` wraz z odpowiednim `user_id`.
 `date` : `string w formacie YYYYmmddhh w czasie CET`
 
 ### `Encounters`
+
+`upload_id` : `string`
 
 `user_id` : `string`
 


### PR DESCRIPTION
W nawiązaniu do https://github.com/ProteGO-app/backend/pull/34  proponuję:
* wyrzucenie `proof`, gdyż oznaczenie chorego nie odbywa się już przez lekarza
* dodanie tabeli `Encounter Uploads` w Datastore do przechowywania informacji o fakcie wgrania danych przez użytkowników
* dodanie `upload_id` do tabeli w BigQuery, żeby móc usunać wszystkie encje z danego uploadu danych, jeśli zgłoszenie zostanie rozpatrzone jako nieprawidłowe
