### PR TITLE
Usunięcie z kontrybutorów

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,7 +14,6 @@ Mikołaj Lewandowski    | [mikolevy](https://github.com/mikolevy)             | 
 Bartosz Paszcza        | [bpaszcza](https://github.com/bpaszcza)             | specs
 Wojciech Dziwulski     | [wojdziw](https://github.com/wojdziw)               | specs
 Wojciech Szkutnik      | [wojtekszkutnik](https://github.com/wojtekszkutnik) | specs
-Szymon Teżewski        | [jasisz](https://github.com/jasisz)                 | backend, specs
 Michał Kuchtar         | [michalkuchtar](https://github.com/michalkuchtar)   | android
 Tomasz Heimowski       | [theimowski](https://github.com/theimowski)         | android
 Adam Kozłowski         | [vetin4ri](https://github.com/vetin4ri)             | backend


### PR DESCRIPTION
Aplikacja jest czymś zupełnie innym niż miała być, prawdopodobnie nie jesttem jedyną osobą wpisaną tutaj, która nie miała żadnego wkładu poza podpisaniem zgody z MC i dyskusją nad poprzednia wersją aplikacji, która jest czymś zupełnie niezwiązanym z aplikacją jaka powstała.

Więcej o moich obiekcjach: https://jasisz.github.io/contact-tracing